### PR TITLE
Added lock_timeout

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: "Lean Delivery Java install"
   company: "Epam Systems"
   license: "Apache"
-  min_ansible_version: "2.7"
+  min_ansible_version: "2.8"
   issue_tracker_url: "https://github.com/lean-delivery/ansible-role-java/issues"
   platforms:
     - name: "Ubuntu"

--- a/tasks/Linux/RedHat.yml
+++ b/tasks/Linux/RedHat.yml
@@ -3,5 +3,6 @@
   yum:
     name: '{{ (transport == "repositories") | ternary(openjdk_package, java_artifact)  }}'
     state: present
+    lock_timeout: 180
   register: package_install
   until: package_install is succeeded

--- a/tasks/System-Linux.yml
+++ b/tasks/System-Linux.yml
@@ -17,6 +17,7 @@
       package:
         name: '{{ requirements }}'
         state: present
+        lock_timeout: 180
       register: installed_packages
       until: installed_packages is succeeded
 


### PR DESCRIPTION
Added the parameter lock_timeout.
lock_timeout has been set 180, the amount of time to wait for the yum lockfile to be freed.
Since lock_timeout has been added in Ansible 2.8, therefore the parameter min_ansible_version also changed to "2.8".