### PR TITLE
Update AdoptOpenJDK api url to fix download fail

### DIFF
--- a/vars/java_distro_configs/adoptopenjdk_vars.yml
+++ b/vars/java_distro_configs/adoptopenjdk_vars.yml
@@ -1,5 +1,5 @@
 ---
-adoptopenjdk_api_page: https://api.adoptopenjdk.net/v2/
+adoptopenjdk_api_page: https://api.adoptopenjdk.net/v3/
 parts: >-
   {{ java_artifact_basename | default('undefined', true)
     | regex_findall('^OpenJ[DKRE]{1,2}[0-9]+U[\-]*([jdkre]+)'


### PR DESCRIPTION
Without this change, running the role with java_distribution: adoptopenjdk and java_major_version: 11 fails when accessing the v2 api.
Updating the version solves the issue.