### PR TITLE
Fix fetching SapMachine 11

### DIFF
--- a/tasks/Linux/fetch/sapmachine-fallback.yml
+++ b/tasks/Linux/fetch/sapmachine-fallback.yml
@@ -11,7 +11,7 @@
     - name: Find release version
       set_fact:
         release_version: >-
-          {{ version_page.content | regex_search('(1.*[.|-]\d)') }}
+          {{ version_page.content | regex_search('(1.*[.|-]\d+)') }}
   when: java_minor_version == '*'
 
 - name: 'Fetch artifact page'


### PR DESCRIPTION
When using this role by the following playbook:
```
include_role:
  name: ansible-role-java
vars:
  java_distribution: sapmachine
  transport: fallback
  java_package: jdk
  java_major_version: 11
```
I'm getting error "SapMachine version 11_x64 for Linux is not supported!"
Executing playbook in verbose mode shows that "Find release version" is giving "ansible_facts": {"release_version": "11.0.1"}
But when going to the releases page:
https://sap.github.io/SapMachine/latest/11
There is "sapmachine-11.0.10", not "11.0.1".
This is because of this regex:
`regex_search('(1.*[.|-]\d)')`
"Find release version" should search for one or more digits, hence mine big, one-letter pull request ;)