### PR TITLE
Add corretto fallback tests to CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,3 +88,25 @@ jobs:
         run: |
           cd ..
           ansible-playbook ansible-role-java/playbook.yml -e "java_major_version=${{ matrix.java_version }} java_distribution=zulu"
+  corretto-fallback:
+    strategy:
+      matrix:
+        java_version:
+          - '11'
+          - '8'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+        with:
+          fetch-depth: 0
+      - name: Install ansible
+        run: |
+          sudo apt-add-repository --yes --update ppa:ansible/ansible
+          sudo apt-get update
+          sudo apt-get install ansible -y
+          ansible --version
+      - name: Run playbook
+        run: |
+          cd ..
+          ansible-playbook ansible-role-java/playbook.yml -e "java_major_version=${{ matrix.java_version }} java_distribution=corretto"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,9 @@ jobs:
     strategy:
       matrix:
         java_version:
+          - '25'
+          - '21'
+          - '17'
           - '11'
           - '8'
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
         run: |
           cd ..
           ansible-playbook ansible-role-java/playbook.yml -e "java_major_version=25"
+      - name: Verify Java installation
+        run: java -version
   openjdk-repo:
     strategy:
       matrix:
@@ -63,6 +65,8 @@ jobs:
         run: |
           cd ..
           ansible-playbook ansible-role-java/playbook.yml -e "java_major_version=${{ matrix.java_version }} transport=repositories"
+      - name: Verify Java installation
+        run: java -version
   zulu-fallback:
     strategy:
       matrix:
@@ -88,6 +92,8 @@ jobs:
         run: |
           cd ..
           ansible-playbook ansible-role-java/playbook.yml -e "java_major_version=${{ matrix.java_version }} java_distribution=zulu"
+      - name: Verify Java installation
+        run: java -version
   corretto-fallback:
     strategy:
       matrix:
@@ -113,3 +119,5 @@ jobs:
         run: |
           cd ..
           ansible-playbook ansible-role-java/playbook.yml -e "java_major_version=${{ matrix.java_version }} java_distribution=corretto"
+      - name: Verify Java installation
+        run: java -version

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ This Ansible role has the following features for:
 - Install JDK
 - Additional opportunity to install from zulu-fallback, s3, web, local source, chocolatey.
 
+**Amazon Corretto**
+
+- Install JDK 8, 11, 17, 21, 25 
+- Install JRE 8 (Amazon Linux 2 only)
+- Additional opportunity to install from fallback, web, local source, s3.
+
 **Oracle Java:**
 
  - Install JRE, JDK, Server-JRE
@@ -47,12 +53,6 @@ This Ansible role has the following features for:
 - Linux/x86_64 platform only
 - Additional opportunity to install from dragonwell8-fallback, web, local source, s3.
 
-**Amazon Corretto**
-
-- Install JDK 8 and 11 
-- Install JRE 8 (Amazon Linux 2 only)
-- Additional opportunity to install from fallback, web, local source, s3.
-
 
 Requirements
 ------------
@@ -76,6 +76,12 @@ Requirements
    - 21
    - 25
  - **Supported zulu version**:
+   - 8
+   - 11
+   - 17
+   - 21
+   - 25
+ - **Supported Amazon Corretto version**:
    - 8
    - 11
    - 17
@@ -116,9 +122,6 @@ Requirements
  - **Supported Alibaba Dragonwell version**:
    - 8.0.0
    - 8.1.1
- - **Supported Amazon Corretto version**:
-   - 8
-   - 11
  - **Supported OS**:
    - Ubuntu
      - bionic
@@ -314,6 +317,31 @@ Example Playbook
       java_distribution: zulu
 ```
 
+### Installing Amazon Corretto JDK 25, 21, 17, 11, 8 from corretto-fallback:
+
+```yaml
+- name: Install Amazon Corretto
+  hosts: all
+
+  roles:
+    - role: lean_delivery.java
+      java_major_version: 25
+      java_distribution: corretto
+```
+
+### Installing Amazon Corretto JDK 11 on Ubuntu 18.04 from web:
+
+```yaml
+- name: Install Amazon Corretto
+  hosts: all
+
+  roles:
+    - role: lean_delivery.java
+      java_distribution: corretto
+      transport: web
+      transport_web: https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz
+```
+
 ### Installing Oracle java 8 from local file:
 ```yaml
 - name: Install oracle java
@@ -396,44 +424,6 @@ https://docs.ansible.com/ansible/latest/modules/aws_s3_module.html#requirements
       java_distribution: dragonwell8
       transport: fallback
       java_major_version: 8
-```
-### Installing Amazon Corretto JDK 8 from corretto-fallback:
-
-```yaml
-- name: Install Amazon Corretto
-  hosts: all
-
-  roles:
-    - role: lean_delivery.java
-      java_distribution: corretto
-      transport: fallback
-      java_major_version: 8
-```
-
-### Installing Amazon Corretto JDK 11 from repo on Amazon Linux 2:
-
-```yaml
-- name: Install Amazon Corretto
-  hosts: all
-
-  roles:
-    - role: lean_delivery.java
-      java_distribution: corretto
-      transport: repositories
-      java_major_version: 11
-```
-
-### Installing Amazon Corretto JDK 11 on Ubuntu 18.04 from web:
-
-```yaml
-- name: Install Amazon Corretto
-  hosts: all
-
-  roles:
-    - role: lean_delivery.java
-      java_distribution: corretto
-      transport: web
-      transport_web: https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz
 ```
 
 License

--- a/tasks/Linux/fetch/corretto-fallback.yml
+++ b/tasks/Linux/fetch/corretto-fallback.yml
@@ -1,11 +1,4 @@
 ---
-- name: Check requested major version for Corretto
-  fail:
-    msg: Supported versions of Amazon Corretto only 8 and 11
-  when:
-    - java_major_version|int != 8
-    - java_major_version|int != 11
-
 - name: Check requested architecture for Corretto
   fail:
     msg: Amazon Corretto currently supports x64 platform only


### PR DESCRIPTION
Add GitHub Actions tests for Amazon Corretto 8 and 11 using fallback transport, following the pattern established by zulu tests.