### PR TITLE
Add LTS Ubuntu versions to supported platforms

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,9 @@ galaxy_info:
       versions:
         - "xenial"
         - "bionic"
+        - "focal"
+        - "jammy"
+        - "noble"
     - name: "Debian"
       versions:
         - "stretch"
@@ -35,14 +38,15 @@ galaxy_info:
     - "system"
     - "packaging"
     - "java"
-    - "oracle"
     - "jdk"
     - "jre"
+    - "oracle"
     - "openjdk"
     - "adoptopenjdk"
     - "sapmachine"
     - "zulu"
     - "sapjvm"
+    - "corretto"
     - "windows"
 
 dependencies: []


### PR DESCRIPTION
Add focal (20.04), jammy (22.04), and noble (24.04) Ubuntu LTS versions to the supported platforms list.